### PR TITLE
Fixes to twitter-worker

### DIFF
--- a/web3-functions/twitter-worker/batchManager.ts
+++ b/web3-functions/twitter-worker/batchManager.ts
@@ -122,12 +122,12 @@ function createUserQueryString(usernames: string[], mintingDayTimestamp: number,
     const untilDayStr = formatDay(mintingDayTimestamp, 1);
     const sinceDayStr = formatDay(mintingDayTimestamp, 0);
     let queryString = `${queryPrefix} since:${sinceDayStr} until:${untilDayStr} AND (`;
-    let recordInsertedCount = 0;
+    let ri = 0; // record inserted count
 
-    for (let i = 0; i < usernames.length; i++) {
-        const username = usernames[i];
+    let usernameAdded = 0;
+    for (; ri < usernames.length; ri++) {
+        const username = usernames[ri];
         if (username == '') {
-            recordInsertedCount++;
             continue;
         }
 
@@ -137,19 +137,18 @@ function createUserQueryString(usernames: string[], mintingDayTimestamp: number,
             break;
         }
 
-        if (i > 0) {
+        if (usernameAdded > 0) {
             queryString += ` OR `;
         }
 
         queryString += nextPart;
-        recordInsertedCount++;
-
+        usernameAdded++;
     }
 
     queryString += ')';
 
     // Close the final query string with parentheses
-    return { queryString, recordInsertedCount };
+    return { queryString, recordInsertedCount: ri };
 }
 
 function createUserQueryStringStatic(usernames: string[], mintingDayTimestamp: number, queryPrefix: string): string {
@@ -186,11 +185,11 @@ function formatDay(timestamp: number, addDays: number): string {
 
 function fillUserIndexByUsernames(logger: Logger, userIndexByUsernames: Map<string, number>, batchUsernames: string[], startIndex: number) {
     for (let i = 0; i < batchUsernames.length; i++) {
-        logger.info(`fillUserIndexByUsernames`, batchUsernames[i], startIndex + i);
         if (batchUsernames[i] == '') {
             continue;
         }
 
+        logger.info(`fillUserIndexByUsernames`, batchUsernames[i], startIndex + i);
         userIndexByUsernames.set(batchUsernames[i], startIndex + i);
     }
 }

--- a/web3-functions/twitter-worker/twitterRequester.ts
+++ b/web3-functions/twitter-worker/twitterRequester.ts
@@ -39,7 +39,6 @@ export class TwitterRequester {
 
         let userIDtoUsername: Map<string, string> = new Map();
         const requests = batches.map(async (batch) => {
-            // const url = `${this.urlList.optimizedServerURLPrefix}/UserResultsByRestIds?user_ids=${batch.join(',')}`;
             const url = `${this.urlList.convertToUsernamesURL}?user_ids=${batch.join(',')}`;
 
             const headerKey = this.secrets.AuthHeaderName;
@@ -67,12 +66,19 @@ export class TwitterRequester {
         await Promise.all(requests);
 
         let results: string[] = [];
+        let emptyConsecutiveCount = 0;
         for (const userID of userIDs) {
             const username = userIDtoUsername.get(userID);
             if (!username) {
                 results.push('');
+                emptyConsecutiveCount++;
+
+                if (emptyConsecutiveCount >= batchSize) {
+                    throw new Error('empty batch for convertToUsernames response, looks wrong');
+                }
                 continue;
             }
+            emptyConsecutiveCount = 0;
 
             results.push(username);
         }


### PR DESCRIPTION
There were issue for Jul 21, that we almost had no $GM receiver.

I did research on it, and found strange bug, that we received array of empty first 100 usernames in convertToUsernames func. We had no issues with this fun before, so I assume one bad request to API. So I added check for that to throw error if we received all usernames batch back as empty.

Also fixed generating X searching query for the case with empty usernames.